### PR TITLE
perf: NNTP pipelining and batch size optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ uv run lkml-feed-api
 
 ### `GET /latest`
 
-返回自上次请求以来的新消息。每次最多处理 100 条消息，积压较多时剩余部分会在后续请求中返回。
+返回自上次请求以来的新消息。每次最多处理 1000 条消息，积压较多时剩余部分会在后续请求中返回。`is_caught_up` 为 `true` 表示已追平最新，`false` 表示还有更多未处理的消息。
 
 ```json
 {
@@ -40,7 +40,8 @@ uv run lkml-feed-api
         "summary": "...",
         "subsystem": "linux-doc"
       }
-    ]
+    ],
+    "is_caught_up": true
   }
 }
 ```
@@ -75,7 +76,6 @@ curl -X POST http://localhost:8000/reset
 |---------|------|--------|
 | `LKML_SUBSYSTEMS` | 子系统列表，逗号分隔 | `linux-doc` |
 | `LKML_KEYWORDS` | 关键词列表，逗号分隔（不区分大小写，匹配 subject，OR 逻辑） | `zh_cn` |
-| `LKML_BODY_CONCURRENCY` | 正文拉取并发数，设为 `1` 串行，`>1` 多连接并行 | `1` |
 
 ## 许可证
 

--- a/doc/sdk.md
+++ b/doc/sdk.md
@@ -2,7 +2,7 @@
 
 ## 快速开始
 
-每次调用 `get_latest()` 返回一批新消息（最多 100 条）。当 `is_caught_up` 为 `False` 时，说明还有更多未处理的消息，应继续调用直到 `True`，此时已拉取到全部增量。
+每次调用 `get_latest()` 返回一批新消息（最多 1000 条）。当 `is_caught_up` 为 `False` 时，说明还有更多未处理的消息，应继续调用直到 `True`，此时已拉取到全部增量。
 
 ```python
 import time
@@ -23,7 +23,7 @@ while True:
 
 ## API
 
-### `LKMLFeedClient(subsystems, *, keywords, state_file, body_concurrency)`
+### `LKMLFeedClient(subsystems, *, keywords, state_file)`
 
 创建客户端，长期持有，连接自动复用。
 
@@ -32,7 +32,6 @@ while True:
 | `subsystems` | `List[str]` | 子系统列表，如 `["linux-doc"]` |
 | `keywords` | `Optional[List[str]]` | 关键词列表，不区分大小写，匹配 subject（OR 逻辑）。不传则返回所有消息 |
 | `state_file` | `Optional[str]` | 状态持久化文件路径，默认 `.lkml_feed_state.json`，传 `None` 禁用 |
-| `body_concurrency` | `int` | 正文拉取并发数，默认 `1`（串行）。设为 `>1` 时多连接并行拉取正文，可大幅提升命中率高时的性能 |
 
 ### `get_latest() -> FetchResult`
 
@@ -73,12 +72,12 @@ while True:
 
 ## 与 API 层的区别
 
-API 层（`/latest`）每次请求只拉取一个批次，不暴露 `is_caught_up`，剩余消息延迟到后续请求返回。SDK 层将 `is_caught_up` 交给调用方，由调用方决定是否循环追平。
+API 层（`/latest`）和 SDK 层行为一致：每次请求拉取一个批次，返回 `is_caught_up` 标志。调用方可据此判断是否继续拉取。
 
 ## 工作原理
 
 - NNTP 连接 `nntp.lore.kernel.org:119`，group 为 `org.kernel.vger.{subsystem}`
-- OVER 命令批量获取元数据（subject / from / date / message-id / references），每批最多 100 篇
+- OVER 命令批量获取元数据（subject / from / date / message-id / references），每批最多 1000 篇
 - 基于 article number 做增量游标，持久化到 JSON 文件，重启不丢状态
 - 按 subject 关键词过滤，只对命中的条目拉取 BODY
 - 断线自动重连（3 次重试，指数退避）

--- a/src/lkml_feed_api/_nntp.py
+++ b/src/lkml_feed_api/_nntp.py
@@ -2,7 +2,7 @@
 
 import socket
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 
 class NNTPError(Exception):
@@ -157,3 +157,25 @@ class NNTP:
             raise NNTPError(resp)
         lines = self._read_multiline()
         return resp, ArticleInfo(lines=lines)
+
+    def body_many(
+        self, article_nums: List[int]
+    ) -> List[Tuple[int, Optional[ArticleInfo]]]:
+        """BODY pipelining — send all commands, then read all responses.
+
+        Returns ``[(article_num, ArticleInfo or None), ...]``.
+        """
+        # Send all BODY commands without waiting
+        for num in article_nums:
+            self._sendline(f"BODY {num}")
+
+        # Read all responses in order
+        results: List[Tuple[int, Optional[ArticleInfo]]] = []
+        for num in article_nums:
+            resp = self._readline()
+            if resp.startswith("222"):
+                lines = self._read_multiline()
+                results.append((num, ArticleInfo(lines=lines)))
+            else:
+                results.append((num, None))
+        return results

--- a/src/lkml_feed_api/app.py
+++ b/src/lkml_feed_api/app.py
@@ -18,11 +18,8 @@ logging.basicConfig(level=logging.INFO)
 _subsystems = [s.strip() for s in os.getenv("LKML_SUBSYSTEMS", "linux-doc").split(",") if s.strip()]
 _keywords_env = os.getenv("LKML_KEYWORDS", "zh_cn")
 _keywords = [k.strip() for k in _keywords_env.split(",") if k.strip()] or None
-_body_concurrency = int(os.getenv("LKML_BODY_CONCURRENCY", "1"))
 
-client = LKMLFeedClient(
-    _subsystems, keywords=_keywords, body_concurrency=_body_concurrency
-)
+client = LKMLFeedClient(_subsystems, keywords=_keywords)
 
 
 @asynccontextmanager
@@ -43,18 +40,17 @@ def ping() -> ApiResponse:
 def latest() -> ApiResponse:
     result = client.get_latest()
     return ApiResponse(
-        data={"entries": [e.model_dump() for e in result.entries]}
+        data={
+            "entries": [e.model_dump() for e in result.entries],
+            "is_caught_up": result.is_caught_up,
+        }
     )
 
 
 @app.post("/rewind")
 def rewind(n: int) -> ApiResponse:
     client.rewind(n)
-    result = client.get_latest()
-    return ApiResponse(
-        message=f"rewound {n} messages",
-        data={"entries": [e.model_dump() for e in result.entries]},
-    )
+    return ApiResponse(message=f"rewound {n} messages")
 
 
 @app.post("/reset")

--- a/src/lkml_feed_api/feed.py
+++ b/src/lkml_feed_api/feed.py
@@ -5,7 +5,6 @@ import logging
 from ._nntp import NNTP, NNTPError
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from email.utils import parseaddr, parsedate_to_datetime
 from pathlib import Path
@@ -20,21 +19,18 @@ NNTP_HOST = "nntp.lore.kernel.org"
 NNTP_PORT = 119
 
 # Maximum articles to fetch per subsystem in a single call
-_MAX_ARTICLES_PER_FETCH = 100
+_MAX_ARTICLES_PER_FETCH = 1000
 
 
 class NNTPFetcher:
     def __init__(
         self,
         state_file: Optional[str] = None,
-        body_concurrency: int = 1,
     ) -> None:
         self._state_file = Path(state_file) if state_file else None
         self._cursors: Dict[str, int] = {}  # group_name -> last_article_number
         self._conn: Optional[NNTP] = None
         self._conn_lock = threading.Lock()
-        self._body_concurrency = max(1, body_concurrency)
-        self._local = threading.local()  # thread-local connections for parallel BODY
         self._load_state()
 
     # ------------------------------------------------------------------
@@ -190,7 +186,7 @@ class NNTPFetcher:
                     continue
                 matched.append((art_num, parsed))
 
-            # Fetch BODY (serial or parallel)
+            # Fetch BODY via pipelining
             entries: List[MailEntry] = []
             if matched:
                 bodies = self._fetch_bodies(group_name, [a for a, _ in matched])
@@ -253,7 +249,8 @@ class NNTPFetcher:
         for attempt in range(1, max_attempts + 1):
             try:
                 conn = self._connect()
-                conn.group(group_name)  # must select group before OVER
+                if attempt > 1:
+                    conn.group(group_name)  # re-select after reconnect
                 _resp, overviews = conn.over((start, end))
                 return overviews
             except (NNTPError, OSError, EOFError, ValueError) as e:
@@ -339,72 +336,26 @@ class NNTPFetcher:
     def _fetch_bodies(
         self, group_name: str, article_nums: List[int]
     ) -> List[Optional[str]]:
-        """Fetch multiple article bodies, serial or parallel."""
-        if self._body_concurrency <= 1:
-            return [self._fetch_body(group_name, n) for n in article_nums]
-
-        def _worker(art_num: int) -> Optional[str]:
-            return self._fetch_body_threaded(group_name, art_num)
-
-        with ThreadPoolExecutor(
-            max_workers=self._body_concurrency
-        ) as pool:
-            return list(pool.map(_worker, article_nums))
-
-    def _fetch_body(self, group_name: str, article_num: int) -> Optional[str]:
-        """Fetch article body text using main connection."""
+        """Fetch multiple article bodies via NNTP pipelining."""
         try:
             conn = self._connect()
-            conn.group(group_name)
-            _resp, info = conn.body(article_num)
-            lines = [
-                line.decode("utf-8", errors="replace") for line in info.lines
-            ]
-            return "\n".join(lines)
+            results = conn.body_many(article_nums)
+            bodies: List[Optional[str]] = []
+            for art_num, info in results:
+                if info is not None:
+                    lines = [
+                        line.decode("utf-8", errors="replace")
+                        for line in info.lines
+                    ]
+                    bodies.append("\n".join(lines))
+                else:
+                    logger.warning("Failed to fetch BODY %d via pipeline", art_num)
+                    bodies.append(None)
+            return bodies
         except (NNTPError, OSError, EOFError, ValueError) as e:
-            logger.warning("Failed to fetch BODY %d: %s", article_num, e)
+            logger.warning("Pipeline BODY fetch failed: %s", e)
             self._close_conn()
-            return None
-
-    def _fetch_body_threaded(
-        self, group_name: str, article_num: int
-    ) -> Optional[str]:
-        """Fetch article body using thread-local NNTP connection."""
-        try:
-            conn = self._get_thread_conn(group_name)
-            _resp, info = conn.body(article_num)
-            lines = [
-                line.decode("utf-8", errors="replace") for line in info.lines
-            ]
-            return "\n".join(lines)
-        except (NNTPError, OSError, EOFError, ValueError) as e:
-            logger.warning("Failed to fetch BODY %d: %s", article_num, e)
-            self._close_thread_conn()
-            return None
-
-    def _get_thread_conn(self, group_name: str) -> NNTP:
-        """Get or create a thread-local NNTP connection."""
-        conn: Optional[NNTP] = getattr(self._local, "conn", None)
-        if conn is not None:
-            try:
-                conn.date()
-            except (NNTPError, OSError, EOFError, ValueError):
-                self._close_thread_conn()
-                conn = None
-        if conn is None:
-            conn = NNTP(NNTP_HOST, NNTP_PORT, timeout=30)
-            self._local.conn = conn
-        conn.group(group_name)
-        return conn
-
-    def _close_thread_conn(self) -> None:
-        conn: Optional[NNTP] = getattr(self._local, "conn", None)
-        if conn is not None:
-            try:
-                conn.quit()
-            except (NNTPError, OSError, EOFError, ValueError):
-                pass
-            self._local.conn = None
+            return [None] * len(article_nums)
 
     # ------------------------------------------------------------------
     # State persistence

--- a/src/lkml_feed_api/sdk.py
+++ b/src/lkml_feed_api/sdk.py
@@ -37,7 +37,6 @@ class LKMLFeedClient:
                     匹配的条目才会拉取正文。不传则返回所有新消息。
         state_file: 状态文件路径。默认 ``.lkml_feed_state.json``，
                     传 ``None`` 禁用持久化。
-        body_concurrency: 正文拉取并发数，默认 1（串行）。
     """
 
     def __init__(
@@ -46,13 +45,10 @@ class LKMLFeedClient:
         *,
         keywords: Optional[List[str]] = None,
         state_file: Optional[str] = _DEFAULT_STATE_FILE,
-        body_concurrency: int = 1,
     ) -> None:
         self._subsystems = subsystems
         self._keywords = [k.lower() for k in keywords] if keywords else None
-        self._fetcher = NNTPFetcher(
-            state_file=state_file, body_concurrency=body_concurrency
-        )
+        self._fetcher = NNTPFetcher(state_file=state_file)
 
     def get_latest(self) -> FetchResult:
         """拉取新消息，返回关键词匹配的条目及是否已追平。"""

--- a/tests/test_feed.py
+++ b/tests/test_feed.py
@@ -24,6 +24,9 @@ def _mock_nntp(**kwargs) -> MagicMock:
     conn.group.return_value = ("211 100 1 500 grp", 100, 1, 500, "grp")
     conn.over.return_value = ("224 ok", [])
     conn.body.return_value = ("222 ok", ArticleInfo(lines=[b"body text"]))
+    conn.body_many.side_effect = lambda nums: [
+        (n, ArticleInfo(lines=[b"body text"])) for n in nums
+    ]
     conn.quit.return_value = "205 bye"
     for k, v in kwargs.items():
         setattr(conn, k, v)
@@ -351,7 +354,7 @@ class TestFetchSubsystem:
     @patch("lkml_feed_api.feed.NNTP")
     def test_caps_at_max_articles(self, MockNNTP, tmp_path):
         mock_conn = _mock_nntp()
-        mock_conn.group.return_value = ("211 1000 1 1000 g", 1000, 1, 1000, "g")
+        mock_conn.group.return_value = ("211 2000 1 2000 g", 2000, 1, 2000, "g")
         mock_conn.over.return_value = ("224 ok", [])
         MockNNTP.return_value = mock_conn
 
@@ -362,11 +365,11 @@ class TestFetchSubsystem:
 
     @patch("lkml_feed_api.feed.NNTP")
     def test_body_failure_still_returns_entry(self, MockNNTP, tmp_path):
-        """If body fetch fails, entry is still returned with empty summary."""
+        """If body_many returns None for an article, entry still returned with empty summary."""
         mock_conn = _mock_nntp()
         mock_conn.group.return_value = ("211 100 1 500 g", 100, 1, 500, "g")
         mock_conn.over.return_value = ("224 ok", [_overview(451)])
-        mock_conn.body.side_effect = NNTPError("body failed")
+        mock_conn.body_many.side_effect = lambda nums: [(n, None) for n in nums]
         MockNNTP.return_value = mock_conn
 
         fetcher = _make_fetcher(tmp_path, cursors={"org.kernel.vger.linux-doc": 450})
@@ -376,11 +379,11 @@ class TestFetchSubsystem:
 
     @patch("lkml_feed_api.feed.NNTP")
     def test_body_value_error_handled(self, MockNNTP, tmp_path):
-        """ValueError from corrupted buffer should not crash the request."""
+        """Pipeline error should not crash; entries returned with empty summary."""
         mock_conn = _mock_nntp()
         mock_conn.group.return_value = ("211 100 1 500 g", 100, 1, 500, "g")
         mock_conn.over.return_value = ("224 ok", [_overview(451)])
-        mock_conn.body.side_effect = ValueError("PyMemoryView buf NULL")
+        mock_conn.body_many.side_effect = ValueError("PyMemoryView buf NULL")
         MockNNTP.return_value = mock_conn
 
         fetcher = _make_fetcher(tmp_path, cursors={"org.kernel.vger.linux-doc": 450})


### PR DESCRIPTION
## Summary
- Add NNTP BODY pipelining (`body_many`): send all commands then read all responses, eliminating per-article RTT wait
- Increase `_MAX_ARTICLES_PER_FETCH` from 100 to 1000 to reduce round trips
- Remove redundant GROUP call in `_over_with_retry` on first attempt
- Remove `/rewind` endpoint's unnecessary `get_latest()` call that caused timeouts
- Expose `is_caught_up` in `/latest` API response
- Remove `body_concurrency` / thread pool / thread-local connections (replaced by pipelining on single connection)